### PR TITLE
corrected macOS url for ltex install

### DIFF
--- a/lua/grammar-guard/installer.lua
+++ b/lua/grammar-guard/installer.lua
@@ -18,7 +18,7 @@ M.install_ltex_ls = function()
       platform="linux"
       ;;
       darwin)
-      platform="macos"
+      platform="mac"
       ;;
 
       esac


### PR DESCRIPTION
The URL was wrong for macOS install, we should run grep on "mac" and not "macos"