### PR TITLE
fix for https://github.com/neovim/nvim-lspconfig/pull/1479

### DIFF
--- a/lua/grammar-guard/base-config.lua
+++ b/lua/grammar-guard/base-config.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 M.setup = function()
-	local configs = require("lspconfig/configs")
-	local util = require("lspconfig/util")
+	local configs = require("lspconfig.configs")
+	local util = require("lspconfig.util")
 
 	local bin_path = require("grammar-guard.vars").bin_path
 


### PR DESCRIPTION
The last lsp config update seems to have broken grammar-guard. I don't quite understand why, but this simple fix seemed to fix my config.