### PR TITLE
feat: make nvim-lsp-installer an optional dependency

### DIFF
--- a/lua/grammar-guard.lua
+++ b/lua/grammar-guard.lua
@@ -5,7 +5,7 @@ M.init = function()
 	-- check if ltex-ls is installed
 	if not is_ltex_installed then
 		vim.notify(
-			"[grammar-guard] The ltex language server has not been installed. Run :GrammarInstall to install it."
+			"[grammar-guard] The ltex language server has not been installed. Run :GrammarInstall to install it (using nvim-lsp-installer) or install it yourself."
 		)
 		return
 	end

--- a/lua/grammar-guard/utils.lua
+++ b/lua/grammar-guard/utils.lua
@@ -14,6 +14,9 @@ M.read_files = function(files)
 end
 
 M._check_ltex_installation = function()
+  if vim.fn.executable('ltex-ls') == 1 then
+    return true
+  end
 	local install_path = require("grammar-guard.vars").install_path
 	if vim.fn.empty(vim.fn.glob(install_path)) > 0 then
 		return false

--- a/readme.md
+++ b/readme.md
@@ -20,10 +20,9 @@ It uses the built-in Neovim LSP to provide feedback while you're writing your L<
 ![Demo](assets/demo.gif)
 
 ## 🌟 Features
-* Easy installer, just run `:GrammarInstall` from Neovim.
+* Easy installer, just run `:GrammarInstall` from Neovim (requires [nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer)).
 * L<big><sup>A</sup></big>T<big><sub>E</sub></big>X, Markdown or plain text grammar checking.
 * Integrates well with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).
-* Using [nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer) for ltex install.
 * Work properly on Windows, Linux, MacOS.
 
 ## ⚡️ Requirements
@@ -66,6 +65,7 @@ Example Configuration:
 ```lua
 -- setup LSP config
 require("lspconfig").grammar_guard.setup({
+  cmd = { '/path/to/ltex-ls' }, -- add this if you install ltex-ls yourself
 	settings = {
 		ltex = {
 			enabled = { "latex", "tex", "bib", "markdown" },


### PR DESCRIPTION
Give the user the choice of `ltex-ls` installation. Using `:GrammarInstall` (which requires `nvim-lsp-installer` plugin to be installed) or via a manual installation.